### PR TITLE
Feature/jharvy Infraestructura Local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 .ONESHELL:
-.PHONY: help install install-hooks lint test sast deps-audit scan-secrets ci-local
+.PHONY: help install install-hooks lint test sast deps-audit scan-secrets ci-local tf-validate tf-plan tf-check tf-apply tf-destroy
 
 help: ## Describe uso de cada target
 	@grep -E '^[a-zA-Z_-]+:.*?## ' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -14,6 +14,25 @@ install-hooks: ## Configura Git para usar nuestros hooks locales
 	git config core.hooksPath .githooks/
 	chmod +x .githooks/*
 
+tf-plan: ## Inicializa la infraestructura y muestra el plan
+	@cd infra/terraform
+	@terraform init && terraform plan
+
+tf-apply: ## Aplica la infraestructura con terraform apply
+	@cd infra/terraform
+	@terraform apply
+
+tf-destroy: ## Destruye la infraestructura con terraform destroy
+	@cd infra/terraform
+	@terraform destroy
+
+tf-validate: ## Ejecuta el formateo y validaciones de la infraestructura
+	@cd infra/terraform
+	@terraform fmt -check && terraform validate
+
+tf-check: ## Ejecuta tflint y tfsec (analizadores de infraestructura)
+	@cd infra/terraform
+	@tflint && tfsec .
 
 lint: ## Ejecuta todos los linters
 	@echo "TODO: Implementar lints"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ tf-validate: ## Ejecuta el formateo y validaciones de la infraestructura
 
 tf-check: ## Ejecuta tflint y tfsec (analizadores de infraestructura)
 	@cd infra/terraform
-	@tflint && tfsec .
+	@tflint && trivy config .
 
 lint: ## Ejecuta todos los linters
 	@echo "TODO: Implementar lints"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,38 @@
 Para el desarrollador:
 
 Ejecuta `make install` para instalar los hooks de git y las dependencias del proyecto.
+
+## Cómo aplicar IaC local (Issue 2)
+
+Este repositorio incluye un stack Terraform mínimo en `infra/terraform` que levanta contenedores Docker para simular un *builder* y un *registry* local.
+
+Requisitos previos:
+- Docker disponible (en WSL usa el socket por defecto `unix:///var/run/docker.sock`).
+- Terraform, tflint y tfsec instalados en tu entorno (o ejecutar desde CI que los provea).
+
+Pasos rápidos:
+
+1. Inicia en la carpeta del repo y valida el Terraform:
+
+```bash
+make tf-validate
+```
+
+2. Ejecuta checks de seguridad/linters para IaC:
+
+```bash
+make tf-check
+```
+
+3. Visualiza (o aplica) el plan:
+
+```bash
+make tf-plan
+# si quieres aplicar:
+cd infra/terraform && terraform apply
+```
+
+Notas:
+- `tf-check` ejecuta `tflint` y `tfsec --severity HIGH`. Si `tfsec` detecta hallazgos de severidad HIGH, el target fallará. Ajusta las reglas en `infra/terraform/.tfsec.yml` o en `.tflint.hcl` según lo necesario.
+- El stack crea un registry en `localhost:5000` y un contenedor `local_builder` que queda corriendo (alpine en bucle). Revisa `infra/terraform/main.tf` para detalles.
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Para el desarrollador:
 
 Ejecuta `make install` para instalar los hooks de git y las dependencias del proyecto.
 
-## Cómo aplicar IaC local (Issue 2)
+## Cómo aplicar IaC local
 
 Este repositorio incluye un stack Terraform mínimo en `infra/terraform` que levanta contenedores Docker para simular un *builder* y un *registry* local.
 
@@ -35,6 +35,6 @@ cd infra/terraform && terraform apply
 ```
 
 Notas:
-- `tf-check` ejecuta `tflint` y `tfsec --severity HIGH`. Si `tfsec` detecta hallazgos de severidad HIGH, el target fallará. Ajusta las reglas en `infra/terraform/.tfsec.yml` o en `.tflint.hcl` según lo necesario.
+- `tf-check` ejecuta `tflint` y `trivy config .`. Si `trivy` detecta hallazgos de severidad HIGH, CRITICAL, LOW y MEDIUM, el target fallará. Ajusta las reglas en `.trivy.yaml` o en `.tflint.hcl` según lo necesario.
 - El stack crea un registry en `localhost:5000` y un contenedor `local_builder` que queda corriendo (alpine en bucle). Revisa `infra/terraform/main.tf` para detalles.
 

--- a/docs/bitacora-sprint1.md
+++ b/docs/bitacora-sprint1.md
@@ -30,3 +30,21 @@ La *Lectura 11* menciona el framework `pre-commit`, pero hemos decidido **usar s
 El problema de los hooks manuales es que fallan si el desarrollador olvida activar su entorno virtual (`source .venv/bin/activate`).
 
 **Nuestra solución:** Los scripts en `.githooks/` son robustos. No llaman a `flake8` directamente, sino que usan la ruta explícita al binario instalado por el `Makefile` (`.venv/bin/flake8`). Esto garantiza que el hook use la versión del proyecto, independientemente de si el venv está activado o no, al menos para las herramientas de Python.
+
+## 5. Infraestructura (Terraform)
+
+Creamos una plantilla inicial de infraestructura en `infra/terraform/main.tf`.
+
+- Propósito:
+	- Tener la definición IaC desde el inicio facilita reproducir entornos y documentar recursos necesarios para despliegues futuros.
+	- Permitir que las validaciones de seguridad (tflint, Trivy, tfsec) se integren en el flujo CI antes de aplicar cambios.
+- Buenas prácticas consideradas:
+	- Gestionar variables sensibles con mecanismos seguros (secret manager o variables de entorno en CI).
+	- Añadir módulos cuando el diseño sea estable para evitar duplicación.
+
+## 6. tflint y Trivy
+
+- tflint: linter para Terraform que escanea la configuración y buenas prácticas en el proyecto.
+- Trivy: escáner para imágenes y también soporta análisis IaC y búsqueda de secretos en el proyecto.
+
+No se utilizo tfsec, ya que se esta integrando en trivy y que funciona bajo el principio de "shift-left security" , lo que significa encontrar problemas lo más temprano posible en el ciclo de desarrollo.

--- a/infra/terraform/.tflint.hcl
+++ b/infra/terraform/.tflint.hcl
@@ -1,0 +1,34 @@
+config {
+  force = false
+}
+
+# Asegura que Terraform tenga versión
+rule "terraform_required_version" {
+  enabled = true
+}
+
+# Para detectar recursos no usados
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+# Asegura que los modulos tengan recurso y version
+rule "terraform_module_pinned_source" {
+  enabled = true
+  style = "semver"
+}
+
+# Asegura que los providers tengan versión
+rule "terraform_required_providers" {
+  enabled = true
+}
+
+# Variables deben estar documentadas
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+# Outputs deben estar documentadas
+rule "terraform_documented_outputs" {
+  enabled = true
+}

--- a/infra/terraform/.tfsec.yml
+++ b/infra/terraform/.tfsec.yml
@@ -1,0 +1,14 @@
+check:
+  enabled: true
+
+severity:
+  include:
+    - HIGH
+    - CRITICAL
+  exclude:
+    - LOW
+    - MEDIUM
+
+config:
+  general-secrets-no-plaintext-exposure:
+    enabled: true

--- a/infra/terraform/.trivy.yaml
+++ b/infra/terraform/.trivy.yaml
@@ -1,0 +1,11 @@
+# Escaner a la configuración (Terraform)
+scanners: config
+
+# Detecta todos los niveles de severidad
+severity: "HIGH,MEDIUM,LOW,CRITICAL"
+
+# Para cuando falla (Util para CI)
+exit-code: 1
+
+# Formato de salida
+format: "table"

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,39 @@
+resource "docker_network" "iac_local_net" {
+  name = "iac_local_net"
+}
+
+resource "docker_image" "registry" {
+  name = "registry:2"
+}
+
+resource "docker_container" "registry" {
+  name  = var.registry_container_name
+  image = docker_image.registry.name
+
+  ports {
+    internal = 5000
+    external = var.registry_external_port
+  }
+
+  networks_advanced {
+    name = docker_network.iac_local_net.name
+  }
+
+  restart = "always"
+}
+
+resource "docker_image" "builder" {
+  name = "alpine:3.18"
+}
+
+resource "docker_container" "builder" {
+  name    = var.builder_container_name
+  image   = docker_image.builder.name
+  command = ["sh", "-c", "while true; do sleep 3600; done"]
+
+  networks_advanced {
+    name = docker_network.iac_local_net.name
+  }
+
+  restart = "no"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "registry_address" {
+  description = "Direccion (host:port) para conectar con el registro local"
+  value       = "localhost:5000"
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "docker" {
+  host = var.docker_host
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "docker_host" {
+  description = "Socket o URL para conectar con el daemon de Docker"
+  type        = string
+  default     = "unix:///var/run/docker.sock"
+}
+
+variable "registry_container_name" {
+  description = "Nombre para el contenedor del registro local"
+  type        = string
+  default     = "local_registry"
+}
+
+variable "builder_container_name" {
+  description = "Nombre para el contenedor del constructor local"
+  type        = string
+  default     = "local_builder"
+}
+
+variable "registry_external_port" {
+  description = "Puerto externo para el registro local"
+  type        = number
+  default     = 5000
+}


### PR DESCRIPTION
## Qué

- Implementación del stack de **Terraform** en `infra/terraform/` para levantar los contenedores locales que simulan el builder y el registro, ademas se agrego sus configuraciones. 
- Implementación de nuevos targets en el **Makefile**:  
  - `make tf-validate`: Ejecuta `terraform fmt -check` y `terraform validate`.  
  - `make tf-check`: Ejecuta `tflint` y `trivy`.  
  - `make tf-plan`: Ejecuta `terraform init && terraform plan`.  
  - `make tf-apply`: Ejecuta `terraform apply`. 
- Actualización del **README.md** con la nueva sección *"Cómo aplicar IaC local"*, explicando cómo usar los nuevos targets.  

## Por qué

- Se provee una forma automatizada, repetible e idempotente de desplegar el entorno de simulación local.  
- Se asegura la calidad, formato y seguridad de la **Infraestructura como Código (IaC)** desde el inicio.  

## Cómo

### 1. Validar Formato y Sintaxis  
```bash
make tf-validate
```

### 2. Validar Calidad y Seguridad:
```bash
make tf-check
```

### 3. Validar el Plan de Despliegue:
```bash
make tf-plan
```

### 4. Aplicar infraestructura:
```bash
make tf-apply
```

Closes #6 